### PR TITLE
Improve connections support, fixes issue #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ By integrating this harness directly into the editor, GDLLM starts ahead of more
 
 ## First-time Setup
 - Download and extract the release zip of your choice (GDLLM + MarkdownLabel recommended) directly into your Godot project directory.
-- Using the **Connections** button in the session panel, link up your inference providers, set their adapter type (OpenAI, Anthropic, or Ollama), and add your API keys.
+- Using the **Connections** button in the session panel, link up your inference providers: pick the Kind (OpenAI, Anthropic, or Ollama), paste the URL your provider hands you (the full endpoint or just the server address, either works) and add API keys where needed. Any OpenAI-compatible server (LM Studio, llama.cpp, vLLM, most others...) uses the OpenAI kind.
 - After the model list refreshes, use the **Effort Configuration** to specify the available thinking levels, cache TTL, and context windows. No provider has an API to retrieve model effort/thinking levels, so they need to be manually identified and added, or the default effort level for the model will be used.
   - Context window size and cache TTL are used to inform context compaction.
   - For providers that report it, context window size is automatically fetched via API.

--- a/addons/gdllm-godot-agentic-harness/gdllm_sources.gd
+++ b/addons/gdllm-godot-agentic-harness/gdllm_sources.gd
@@ -11,7 +11,7 @@ const KIND_OLLAMA := "ollama" ## Native Ollama wire format (/api/chat NDJSON), u
 const KIND_OPENAI := "openai" ## OpenAI-compatible wire format (/v1/chat/completions SSE), used by vLLM, Poolside, etc.
 const KIND_ANTHROPIC := "anthropic" ## Anthropic Messages API wire format (/v1/messages SSE), used by the Claude models.
 
-const DEFAULT_OLLAMA_LOCAL_BASE := "http://192.168.1.104:11434" ## Seed endpoint for the first-run local source; the pre-multi-source default.
+const DEFAULT_OLLAMA_LOCAL_BASE := "http://localhost:11434" ## Seed endpoint for the first-run local source; the pre-multi-source default.
 const DEFAULT_ANTHROPIC_BASE := "https://api.anthropic.com" ## Anthropic's API host; the same for every account, so the Connections dialog prefills it when a row switches to the Anthropic kind.
 
 

--- a/addons/gdllm-godot-agentic-harness/gdllmchat.gd
+++ b/addons/gdllm-godot-agentic-harness/gdllmchat.gd
@@ -7,6 +7,21 @@ const MANAGE_COL_DELETE := 11 ## Column in the manage table holding each row's t
 const MANAGE_RESIZE_MARGIN := 5.0 ## Half-width in px of the grab zone around a column boundary in the manage table's title strip.
 const MANAGE_COL_MIN_WIDTH := 40 ## Narrowest a manage-table column can be drag-resized down to.
 const CONNECTION_TOGGLE_WIDTH := 34 ## Fixed width of the Connections dialog's per-source enabled column; the header label and each row's checkbox share it so columns line up (mirrors the delete button's 34px).
+## Per-kind guidance for the Connections dialog's URL field — placeholder for a blank field, tooltip for a filled one. The field takes the URL the provider's own UI hands out, full endpoint or bare base alike (each adapter derives its routes from the server root; see LLMAdapter._root_from_endpoint), so the guidance shows the form users actually copy.
+const CONNECTION_BASE_URL_HINTS := {
+	GDLLMSources.KIND_OLLAMA: {
+		"placeholder": "http://localhost:11434",
+		"tooltip": "Paste the server's address. A bare host and port like http://localhost:11434, or a full endpoint like .../api/chat; every route is derived from the server root either way.",
+	},
+	GDLLMSources.KIND_OPENAI: {
+		"placeholder": "http://localhost:1234/v1/chat/completions",
+		"tooltip": "Paste the URL your server hands out, a full endpoint like http://localhost:1234/v1/chat/completions, a base ending in /v1, or a bare host and port (/v1 is then added automatically) all work.",
+	},
+	GDLLMSources.KIND_ANTHROPIC: {
+		"placeholder": "https://api.anthropic.com",
+		"tooltip": "Anthropic's endpoint is the same for everyone: https://api.anthropic.com — pasting the full …/v1/messages endpoint works too.",
+	},
+}
 const EFFORT_LEVEL_COL_WIDTH := 62 ## Fixed width of each level column in the Effort Configuration table; the header label and each row's checkbox share it so columns line up, wide enough for "minimal".
 const EFFORT_CACHE_COL_WIDTH := 84 ## Fixed width of the Effort Configuration table's cache-TTL column; the header label and each row's spinbox share it so the column lines up.
 const EFFORT_CONTEXT_COL_WIDTH := 140 ## Fixed width of the Effort Configuration table's declared-context-window column; sized for an eight-digit token figure beside the spin arrows, so a millions-scale window never clips.
@@ -591,7 +606,7 @@ func _ensure_connections_dialog() -> void:
 	content.add_theme_constant_override("separation", 8)
 
 	var hint := Label.new()
-	hint.text = "Each source is a place models come from. Kind sets the wire format: Ollama (local or cloud), OpenAI-compatible (vLLM, Poolside, …), or Anthropic (Claude models). Paste an API key for sources that need one — keys are stored locally in Editor Settings and never committed. Save, then Refresh Models to pull each source's models into the pickers."
+	hint.text = "Each source is a place models come from. Kind sets the wire format: Ollama (local or cloud), OpenAI-compatible (LM Studio, llama.cpp, vLLM, Poolside, most others...), or Anthropic (Claude models). For the URL, paste what your provider hands you — the full endpoint or just the server's address; every route is derived from it. Paste an API key for sources that need one — keys are stored locally in Editor Settings and never committed. Save, then Refresh Models to pull each source's models into the pickers."
 	hint.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
 	content.add_child(hint)
 
@@ -602,7 +617,7 @@ func _ensure_connections_dialog() -> void:
 	on_head.text = "On"
 	on_head.custom_minimum_size = Vector2(CONNECTION_TOGGLE_WIDTH, 0)
 	head.add_child(on_head)
-	for spec in [["Name", 2.0], ["Kind", 1.0], ["Base URL", 3.0], ["API key", 2.0]]:
+	for spec in [["Name", 2.0], ["Kind", 1.0], ["URL", 3.0], ["API key", 2.0]]:
 		var col := Label.new()
 		col.text = String(spec[0])
 		col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -674,13 +689,15 @@ func _add_connection_row(source: Dictionary) -> void:
 
 	var base_edit := LineEdit.new()
 	base_edit.text = String(source.get("base_url", ""))
-	base_edit.placeholder_text = "http://host:port  or  https://…/v1"
+	_apply_base_url_hint(base_edit, current_kind)
 	base_edit.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	base_edit.size_flags_stretch_ratio = 3.0
 	row.add_child(base_edit)
-	# Anthropic's endpoint is the same for everyone, so switching a still-blank row to that kind fills it in — one less thing to look up when adding the source by hand.
 	kind_select.item_selected.connect(func(index: int) -> void:
-		if base_edit.text.strip_edges() == "" and String(kind_select.get_item_metadata(index)) == GDLLMSources.KIND_ANTHROPIC:
+		var kind := String(kind_select.get_item_metadata(index))
+		_apply_base_url_hint(base_edit, kind)
+		# Anthropic's endpoint is the same for everyone, so switching a still-blank row to that kind fills it in — one less thing to look up when adding the source by hand.
+		if base_edit.text.strip_edges() == "" and kind == GDLLMSources.KIND_ANTHROPIC:
 			base_edit.text = GDLLMSources.DEFAULT_ANTHROPIC_BASE)
 
 	var key_edit := LineEdit.new()
@@ -709,6 +726,13 @@ func _add_connection_row(source: Dictionary) -> void:
 	}
 	_connection_rows.append(entry)
 	del.pressed.connect(func() -> void: _remove_connection_row(entry))
+
+
+## Stamp `base_edit` with `kind`'s URL guidance (see CONNECTION_BASE_URL_HINTS) — the placeholder shows on a blank field, the tooltip on hover either way. Re-applied whenever the row's kind changes, so the guidance always describes the selected wire format.
+func _apply_base_url_hint(base_edit: LineEdit, kind: String) -> void:
+	var hint: Dictionary = CONNECTION_BASE_URL_HINTS.get(kind, {})
+	base_edit.placeholder_text = String(hint.get("placeholder", "http://host:port"))
+	base_edit.tooltip_text = String(hint.get("tooltip", ""))
 
 
 func _remove_connection_row(entry: Dictionary) -> void:
@@ -764,7 +788,8 @@ func _on_connections_confirmed() -> void:
 
 func _on_connections_custom_action(action: StringName) -> void:
 	if action == "add_source":
-		_add_connection_row({"kind": GDLLMSources.KIND_OLLAMA})
+		# Fresh rows default to the OpenAI kind
+		_add_connection_row({"kind": GDLLMSources.KIND_OPENAI})
 	elif action == "refresh_models":
 		_save_connections() # persist edits first so the sweep hits the current URLs and keys
 		refresh_all_models()

--- a/addons/gdllm-godot-agentic-harness/llm_adapters.gd
+++ b/addons/gdllm-godot-agentic-harness/llm_adapters.gd
@@ -70,12 +70,20 @@ func parse_completion_stats(_data: Variant) -> Dictionary:
 	return {}
 
 
-## The base URL as actually dialed: trimmed, trailing slashes dropped so joining an adapter path can't double the separator. Subclasses may add provider-specific repair (see OpenAIAdapter).
+## The base URL as actually dialed: trimmed, trailing slashes dropped so joining an adapter path can't double the separator. Each subclass further reduces a pasted full endpoint to its server root (see _root_from_endpoint), so the URL a provider's UI hands out works as-is.
 func normalize_base(base: String) -> String:
 	var out := base.strip_edges()
 	while out.ends_with("/"):
 		out = out.trim_suffix("/")
 	return out
+
+
+## The server root behind a stored URL that may be a full endpoint rather than a base: the first matching known endpoint suffix is stripped, so the URL a provider's UI hands out (LM Studio's …/v1/chat/completions, Ollama's …/api/chat) works pasted as-is, while a URL carrying no known suffix — a bare host:port or one with a proxy prefix — passes through untouched for the adapter's own paths to join. `suffixes` must be ordered most-specific first; only the first match is stripped.
+static func _root_from_endpoint(base: String, suffixes: Array) -> String:
+	for suffix in suffixes:
+		if base.ends_with(String(suffix)):
+			return base.left(base.length() - String(suffix).length())
+	return base
 
 
 ## The auth headers for a source's `api_key` — a Bearer token when set, none when empty. Shared by both wire formats (Ollama Cloud and the OpenAI-compatible providers all take `Authorization: Bearer`).
@@ -164,6 +172,10 @@ class OllamaAdapter extends LLMAdapter:
 
 	func models_path() -> String:
 		return "/api/tags"
+
+	## A pasted full endpoint (Ollama's docs hand out …/api/chat and friends) reduces to its server root; anything else — a bare host:port, or a reverse-proxy prefix — passes through and the /api/… paths join after it.
+	func normalize_base(base: String) -> String:
+		return _root_from_endpoint(super.normalize_base(base), ["/api/chat", "/api/generate", "/api/tags", "/api/show", "/api"])
 
 	func parse_models(data: Variant) -> PackedStringArray:
 		var names := PackedStringArray()
@@ -254,9 +266,9 @@ class OpenAIAdapter extends LLMAdapter:
 	func models_path() -> String:
 		return "/models"
 
-	## A pathless base (e.g. "http://localhost:8000" for a local vLLM) gets "/v1" appended, since every OpenAI-compatible server serves under it; a base that already carries a path (Poolside's "/v1", a gateway's custom prefix) is respected as-is.
+	## A pasted full endpoint (the URL an OpenAI-compatible server's UI hands out, e.g. LM Studio's …/v1/chat/completions) reduces to its serving base first. Then a pathless base (e.g. "http://localhost:8000" for a local vLLM) gets "/v1" appended, since every OpenAI-compatible server serves under it; a base that still carries a path (Poolside's "/v1", a gateway's custom prefix) is respected as-is.
 	func normalize_base(base: String) -> String:
-		var out := super.normalize_base(base)
+		var out := _root_from_endpoint(super.normalize_base(base), ["/chat/completions", "/completions", "/models", "/embeddings"])
 		var scheme_end := out.find("://")
 		var host_start := scheme_end + 3 if scheme_end != -1 else 0
 		if out.find("/", host_start) == -1 and out != "":
@@ -506,6 +518,10 @@ class AnthropicAdapter extends LLMAdapter:
 	func models_path() -> String:
 		# The default page is 20 entries; raise the limit so one fetch covers the whole catalog.
 		return "/v1/models?limit=100"
+
+	## A pasted full endpoint (…/v1/messages, or a base ending in /v1) reduces to the server root the /v1/… paths join to, so the URL Anthropic's docs hand out works as-is; a gateway prefix passes through untouched.
+	func normalize_base(base: String) -> String:
+		return _root_from_endpoint(super.normalize_base(base), ["/v1/messages", "/v1/models", "/v1"])
 
 	func parse_models(data: Variant) -> PackedStringArray:
 		var names := PackedStringArray()

--- a/addons/gdllm-godot-agentic-harness/llm_client.gd
+++ b/addons/gdllm-godot-agentic-harness/llm_client.gd
@@ -14,7 +14,7 @@ const STREAM_CONNECT_TIMEOUT := 15.0 ## Seconds to wait for the socket before gi
 const BODY_EXCERPT_CHARS := 180 ## How much of an unparseable response body an error message may quote — enough to recognize what answered, short enough that a whole HTML page never lands in the log.
 const TAGS_TIMEOUT := 12.0 ## Seconds a model-list fetch may run before it resolves as empty. Enforced with a SceneTreeTimer, not HTTPRequest.timeout — that internal timer fails to start for a node built in _init, leaving an unreachable host's fetch to hang forever and any sweep awaiting it stuck.
 
-@export var api_base: String = "http://192.168.1.104:11434" ## The API endpoint, local or remote.
+@export var api_base: String = "http://localhost:11434" ## The API endpoint, local or remote.
 @export var model: String = "nemotron-3-nano:30b"
 @export var api_key: String = "" ## Bearer token for sources that need one (Ollama Cloud, Poolside); empty for local/no-auth endpoints.
 @export var adapter_kind: String = "ollama" ## Which wire format this client speaks (see GDLLMSources.KIND_*); selects the LLMAdapter used to build and parse requests.
@@ -167,6 +167,9 @@ func _on_tags_completed(result: int, response_code: int, _headers: PackedStringA
 	if response_code != 200:
 		# The body rides along because it's what tells e.g. a bad API key (a 401 that says so) apart from a dead route.
 		last_models_error = "HTTP %d: %s" % [response_code, body.get_string_from_utf8().strip_edges().left(300)]
+		# A 404 on the models path almost always means the Base URL's shape doesn't match the kind, so the error names the fix instead of leaving only the provider's complaint.
+		if response_code == 404:
+			last_models_error += " — " + _kind_404_hint()
 		push_warning("LLMClient: model list fetch failed (%s)" % last_models_error)
 		_emit_models(PackedStringArray())
 		return
@@ -179,6 +182,15 @@ func _on_tags_completed(result: int, response_code: int, _headers: PackedStringA
 	var names := _make_adapter().parse_models(json.get_data())
 	names.sort()
 	_emit_models(names)
+
+
+## The likely fix for a 404 on this kind's model-list path — in practice a URL or Kind that doesn't match the server (see each adapter's normalize_base and the Connections dialog's per-kind hints) — appended to last_models_error so the failure guides to the solution instead of only quoting the provider.
+func _kind_404_hint() -> String:
+	if adapter_kind == GDLLMSources.KIND_OPENAI:
+		return "check the source's URL and Kind: a bare http://host:port, a base ending in /v1, or a full endpoint like …/v1/chat/completions all work for an OpenAI-compatible server — an Ollama server needs the Ollama kind instead"
+	if adapter_kind == GDLLMSources.KIND_ANTHROPIC:
+		return "check the source's URL: Anthropic wants https://api.anthropic.com (pasting the full …/v1/messages endpoint works too)"
+	return "check the source's URL and Kind: an Ollama server takes a bare http://host:port or a full endpoint like …/api/chat — an OpenAI-compatible server (LM Studio, llama.cpp, vLLM, most others...) needs the OpenAI kind instead"
 
 
 ## Emit the model list exactly once per fetch, so a late response and the timeout can't both fire models_received (which would double-count the source in a sweep).

--- a/addons/gdllm-godot-agentic-harness/tools/anthropic_adapter_test.gd
+++ b/addons/gdllm-godot-agentic-harness/tools/anthropic_adapter_test.gd
@@ -31,6 +31,7 @@ func _init() -> void:
 	_test_ollama_strips_foreign_fields()
 	_test_output_caps()
 	_test_context_probe()
+	_test_normalize_base()
 	print("%s: %d checks, %d failures" % ["FAIL" if _failures > 0 else "OK", _checks, _failures])
 	quit(1 if _failures > 0 else 0)
 
@@ -379,3 +380,25 @@ func _test_context_probe() -> void:
 	_check(openai.parse_context_window({"data": [{"id": "groq-model", "context_window": 32768.0}]}, "groq-model") == 32768, "Groq's context_window is recognized")
 	_check(openai.parse_context_window(models_body, "absent-model") == 0, "a model not in the list stays unknown")
 	_check(openai.parse_context_window({"data": [{"id": "plain-model"}]}, "plain-model") == 0, "an entry with no window field stays unknown")
+
+
+func _test_normalize_base() -> void:
+	var ollama := LLMAdapters.OllamaAdapter.new()
+	_check(ollama.normalize_base("http://localhost:11434") == "http://localhost:11434", "an ollama bare host:port passes through")
+	_check(ollama.normalize_base(" http://localhost:11434/ ") == "http://localhost:11434", "whitespace and trailing slashes are trimmed")
+	_check(ollama.normalize_base("http://localhost:11434/api/chat") == "http://localhost:11434", "a pasted ollama chat endpoint reduces to its root")
+	_check(ollama.normalize_base("http://localhost:11434/api/tags") == "http://localhost:11434", "a pasted ollama tags endpoint reduces to its root")
+	_check(ollama.normalize_base("http://localhost:11434/api") == "http://localhost:11434", "a pasted bare /api reduces to its root")
+	_check(ollama.normalize_base("https://gw.example/ollama") == "https://gw.example/ollama", "an unrecognized path is kept as a proxy prefix")
+	var openai := LLMAdapters.OpenAIAdapter.new()
+	_check(openai.normalize_base("http://localhost:1234") == "http://localhost:1234/v1", "an openai pathless base gets /v1 appended")
+	_check(openai.normalize_base("http://localhost:1234/v1") == "http://localhost:1234/v1", "an openai /v1 base is respected as-is")
+	_check(openai.normalize_base("http://localhost:1234/v1/chat/completions") == "http://localhost:1234/v1", "a pasted openai chat endpoint reduces to its /v1 base")
+	_check(openai.normalize_base("http://localhost:1234/v1/models") == "http://localhost:1234/v1", "a pasted openai models endpoint reduces to its /v1 base")
+	_check(openai.normalize_base("http://localhost:1234/chat/completions") == "http://localhost:1234/v1", "a v1-less pasted chat endpoint reduces to the root and regains /v1")
+	_check(openai.normalize_base("https://gw.example/llm/v1") == "https://gw.example/llm/v1", "an openai gateway prefix is respected as-is")
+	var anthropic := LLMAdapters.AnthropicAdapter.new()
+	_check(anthropic.normalize_base("https://api.anthropic.com") == "https://api.anthropic.com", "an anthropic bare base passes through")
+	_check(anthropic.normalize_base("https://api.anthropic.com/v1/messages") == "https://api.anthropic.com", "a pasted anthropic messages endpoint reduces to its root")
+	_check(anthropic.normalize_base("https://api.anthropic.com/v1") == "https://api.anthropic.com", "a pasted /v1 base reduces to the root the /v1/… paths rejoin")
+	_check(anthropic.normalize_base("https://gw.example/anthropic/v1/messages") == "https://gw.example/anthropic", "a gateway-prefixed endpoint keeps its prefix as the root")


### PR DESCRIPTION
- Connection URLs now accept whatever your provider hands you. Paste the full endpoint or just the server address, and GDLLM derives the correct route. Reverse-proxy and gateway setups should not be affected. 
- Improve guidance in the Connections dialog.
- Model-list 404 errors more effectively guide the user.
- Changed ollama default url to use `localhost`

Fixes issue #1 